### PR TITLE
Fix query builder

### DIFF
--- a/lib/influxer/metrics/relation/time_query.rb
+++ b/lib/influxer/metrics/relation/time_query.rb
@@ -4,7 +4,8 @@ module Influxer
       hour: '1h',
       minute: '1m',
       second: '1s',
-      ms: '1u',
+      ms: '1ms',
+      u: '1u',
       week: '1w',
       day: '1d',
       month: '30d'

--- a/spec/metrics/scoping_spec.rb
+++ b/spec/metrics/scoping_spec.rb
@@ -42,14 +42,14 @@ describe Influxer::Metrics, :query do
 
     it "works with several defaults" do
       expect(dappy.where(user_id: 1).to_sql)
-        .to eq "select * from \"dummy\" group by time(1h) where (user_id=1) limit 100"
+        .to eq "select * from \"dummy\" where (user_id=1) group by time(1h) limit 100"
     end
   end
 
   describe "named scope" do
     it "works with named scope" do
       expect(doomy.by_user(1).to_sql)
-        .to eq "select * from \"dummy\" group by time(1h) where (user_id=1) limit 100"
+        .to eq "select * from \"dummy\" where (user_id=1) group by time(1h) limit 100"
     end
 
     it "works with named scope with empty relation" do
@@ -58,7 +58,7 @@ describe Influxer::Metrics, :query do
 
     it "works with several scopes" do
       expect(doomy.where(dummy_id: 100).by_user([1, 2, 3]).daily.to_sql)
-        .to eq "select * from \"dummy\" group by time(1d) where (dummy_id=100) and (user_id=1 or user_id=2 or user_id=3) limit 100"
+        .to eq "select * from \"dummy\" where (dummy_id=100) and (user_id=1 or user_id=2 or user_id=3) group by time(1d) limit 100"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,10 @@ class Rails
     def logger
       @logger ||= Logger.new(nil)
     end
+
+    def env
+      'test'
+    end
   end
 end
 


### PR DESCRIPTION
Fix order of statements (according to specification).
Add `Relation#order` method.
Add `Relation#slimit` and `Relation#soffset` methods.
