### PR TITLE
Fix delete all method

### DIFF
--- a/lib/influxer/client.rb
+++ b/lib/influxer/client.rb
@@ -6,10 +6,5 @@ module Influxer
     def initialize
       super Influxer.config.as_json.symbolize_keys!
     end
-
-    # Public #execute
-    def exec(sql)
-      execute(sql)
-    end
   end
 end

--- a/lib/influxer/metrics/relation.rb
+++ b/lib/influxer/metrics/relation.rb
@@ -194,7 +194,7 @@ module Influxer
 
       sql = sql.join " "
 
-      @instance.client.exec sql
+      @instance.client.query sql
     end
 
     def scoping

--- a/spec/metrics/relation_spec.rb
+++ b/spec/metrics/relation_spec.rb
@@ -294,6 +294,15 @@ describe Influxer::Relation, :query do
   end
 
   describe "#delete_all" do
+    it "client expects to execute query method" do
+      expected_query = "drop series from \"dummy\""
+
+      expect(client)
+        .to receive(:query).with(expected_query)
+
+      rel.delete_all
+    end
+
     it "without tags" do
       expect(rel.delete_all)
         .to eq "drop series from \"dummy\""

--- a/spec/support/shared_contexts/shared_query.rb
+++ b/spec/support/shared_contexts/shared_query.rb
@@ -7,10 +7,6 @@ shared_context "stub_query", :query do
       sql
     end
 
-    allow_any_instance_of(Influxer::Client).to receive(:exec) do |_, sql|
-      sql
-    end
-
     allow_any_instance_of(InfluxDB::Client).to receive(:post)
   end
 end


### PR DESCRIPTION
Fix InfluxDB::QueryError: database name required on delete_all method.