### PR TITLE
Allow points to respond to fields.

### DIFF
--- a/lib/influxer/metrics/relation.rb
+++ b/lib/influxer/metrics/relation.rb
@@ -274,8 +274,13 @@ module Influxer
 
     def get_points(list)
       return list if normalized?
-      list.reduce([]) do |a, e|
-        a + e.fetch("values", []).map { |v| inject_tags(v, e["tags"] || {}) }
+      list.reduce([]) do |memo, element|
+        memo + element.fetch('values', []).map do |value|
+          data_as_hash = inject_tags(value, element['tags'] || {})
+
+          influxer_obj = Struct.new(*data_as_hash.keys.map(&:to_sym))
+          influxer_obj.new(*data_as_hash.values)
+        end
       end
     end
 

--- a/spec/cases/points_spec.rb
+++ b/spec/cases/points_spec.rb
@@ -15,9 +15,26 @@ describe DummyMetrics do
     context "default format (values merged with tags)" do
       subject { described_class.all.to_a }
 
-      it "returns array of hashes" do
-        expect(subject.first).to include("host" => "server01", "region" => "us-west", "value" => 0.64)
-        expect(subject.second).to include("host" => "server01", "region" => "us-west", "value" => 0.93)
+      it 'returns an array of structs' do
+        expect(subject.first).to be_a Struct
+        expect(subject.second).to be_a Struct
+      end
+
+      it "responds to all the key elements of the parsed series" do
+        expected_methods = [:host, :region, :value]
+
+        subject.each do |object|
+          expect(object).to respond_to(*expected_methods)
+        end
+      end
+
+      it 'returns the expected value for all the key elements of the parsed series' do
+        a_series = { "host" => "server01", "region" => "us-west", "value" => 0.93 }
+        parsed_series = subject.last
+
+        a_series.each_pair do |key, value|
+          expect(parsed_series.public_send(key.to_sym)).to eq value
+        end
       end
     end
   end


### PR DESCRIPTION
This change parses a hash result (an element of a relation), to a struct object in order to simplify the access to different attributes.

e.g.

```ruby
=begin
point looks like this:
{
  "time"=>"2016-07-28T19:38:09.375Z",
  "cities_count"=>nil,
  "bedrooms_count"=>11,
  "guid_id"=>"ABC123DEF",
}
=end

point  = Metrics.limit(1).to_a.first
point.time # Thu, 28 Jul 2016 19:38:09 +0000
point.user_count # nil
point.house_count # 11
point.guid # "ABC123DEF"
```