### PR TITLE
Setter for retention policy

### DIFF
--- a/lib/influxer/metrics/metrics.rb
+++ b/lib/influxer/metrics/metrics.rb
@@ -33,6 +33,7 @@ module Influxer
 
       attr_reader :series
       attr_accessor :tag_names
+      attr_accessor :retention_policy
 
       def attributes(*attrs)
         attrs.each do |name|
@@ -59,6 +60,10 @@ module Influxer
       def inherited(subclass)
         subclass.set_series
         subclass.tag_names = tag_names.nil? ? [] : tag_names.dup
+      end
+
+      def set_retention_policy(policy_name)
+        @retention_policy = policy_name
       end
 
       # rubocop:disable Metrics/MethodLength
@@ -102,9 +107,18 @@ module Influxer
             quoted_series(val.first)
           end
         else
-          '"' + val.to_s.gsub(/\"/) { '\"' } + '"'
+          if retention_policy.present?
+            [quote(@retention_policy), quote(val)].join('.')
+          else
+            quote(val)
+          end
         end
       end
+
+      def quote(name)
+        '"' + name.to_s.gsub(/\"/) { '\"' } + '"'
+      end
+
       # rubocop:enable Metrics/MethodLength
     end
 

--- a/spec/metrics/metrics_spec.rb
+++ b/spec/metrics/metrics_spec.rb
@@ -11,6 +11,7 @@ describe Influxer::Metrics, :query do
 
     specify { is_expected.to respond_to :attributes }
     specify { is_expected.to respond_to :set_series }
+    specify { is_expected.to respond_to :set_retention_policy }
     specify { is_expected.to respond_to :series }
     specify { is_expected.to respond_to :write }
     specify { is_expected.to respond_to :write! }
@@ -135,6 +136,26 @@ describe Influxer::Metrics, :query do
 
       m = dummy_with_proc_series.new user_id: 2, test_id: 123
       expect(m.series).to eq "\"test/123/user/2\""
+    end
+  end
+
+  describe "#quoted_series" do
+    context "with retention policy" do
+      let(:dummy_with_retention_policy) do
+        Class.new(described_class) do
+          attributes :user_id, :test_id
+          set_series :dummies
+          set_retention_policy :week
+        end
+      end
+
+      it "sets retention policy" do
+        expect(dummy_with_retention_policy.retention_policy).to eq :week
+      end
+
+      it "sets quoted series with retention policy" do
+        expect(dummy_with_retention_policy.quoted_series).to eq "\"week\".\"dummies\""
+      end
     end
   end
 


### PR DESCRIPTION
There is problem if a measurement has another retention policy than <autogen> (default). I tried to fix that problem in the PR.
