### PR TITLE
Fix require order of ActiveModel

### DIFF
--- a/lib/influxer.rb
+++ b/lib/influxer.rb
@@ -1,4 +1,5 @@
 require 'influxer/version'
+require 'active_model'
 
 # Rails client for InfluxDB
 module Influxer

--- a/lib/influxer/metrics/metrics.rb
+++ b/lib/influxer/metrics/metrics.rb
@@ -1,7 +1,6 @@
 require 'influxer/metrics/relation'
 require 'influxer/metrics/scoping'
 require 'influxer/metrics/active_model3/model'
-require 'active_model'
 
 module Influxer
   class MetricsError < StandardError; end


### PR DESCRIPTION
I made a mistake in my last PR.

Forgot to require the `active_model` library before declaring the `ActiveModel::Version::MAJOR`

The specs were passing because there is a `require active_record` in spec_helper.rb.
But if you try to use this library without preloading Rails or ActiveRecord, it will throw a `uninitialized constant Influxer::ActiveModel` error.

Sorry for any incoveniences.