### PR TITLE
Consistent quoting of timestamps for INSERTs and SELECT

### DIFF
--- a/lib/influxer/metrics/metrics.rb
+++ b/lib/influxer/metrics/metrics.rb
@@ -2,6 +2,7 @@
 
 require 'influxer/metrics/relation'
 require 'influxer/metrics/scoping'
+require 'influxer/metrics/quoting/timestamp'
 require 'influxer/metrics/active_model3/model'
 
 module Influxer
@@ -25,6 +26,7 @@ module Influxer
     extend ActiveModel::Callbacks
 
     include Influxer::Scoping
+    include Influxer::TimestampQuoting
 
     define_model_callbacks :write
 
@@ -227,18 +229,7 @@ module Influxer
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def parsed_timestamp
-      return @timestamp unless client.time_precision == 'ns'
-
-      case @timestamp
-      when Numeric
-        @timestamp.to_i.to_s.ljust(19, '0').to_i
-      when String
-        (Time.parse(@timestamp).to_r * TIME_FACTOR).to_i
-      when Date
-        (@timestamp.to_time.to_r * TIME_FACTOR).to_i
-      when Time
-        (@timestamp.to_r * TIME_FACTOR).to_i
-      end
+      quote_timestamp @timestamp, client
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize

--- a/lib/influxer/metrics/quoting/timestamp.rb
+++ b/lib/influxer/metrics/quoting/timestamp.rb
@@ -1,0 +1,21 @@
+module Influxer
+  module TimestampQuoting #:nodoc:
+    TIME_FACTOR = 1_000_000_000
+
+    # Quote timestamp as ns
+    def quote_timestamp(val, client)
+      return val unless client.time_precision == 'ns'
+
+      case val
+      when Numeric
+        val.to_i.to_s.ljust(19, '0').to_i
+      when String
+        (Time.parse(val).to_r * TIME_FACTOR).to_i
+      when Date, DateTime
+        (val.to_time.to_r * TIME_FACTOR).to_i
+      when Time      
+        (val.to_r * TIME_FACTOR).to_i
+      end
+    end
+  end
+end

--- a/lib/influxer/metrics/relation.rb
+++ b/lib/influxer/metrics/relation.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/module/delegation'
 require 'influxer/metrics/relation/time_query'
 require 'influxer/metrics/relation/calculations'
 require 'influxer/metrics/relation/where_clause'
+require 'influxer/metrics/quoting/timestamp'
 
 module Influxer
   # Relation is used to build queries
@@ -11,6 +12,7 @@ module Influxer
   class Relation
     include Influxer::TimeQuery
     include Influxer::Calculations
+    include Influxer::TimestampQuoting
     prepend Influxer::WhereClause
 
     attr_reader :values
@@ -269,8 +271,8 @@ module Influxer
     def quoted(val, key = nil)
       if val.is_a?(String) || val.is_a?(Symbol) || @klass.tag?(key)
         "'#{val}'"
-      elsif val.is_a?(Time) || val.is_a?(DateTime)
-        "#{val.to_i}s"
+      elsif val.is_a?(Time) || val.is_a?(Date) || val.is_a?(DateTime)
+        quote_timestamp val, @instance.client
       else
         val.to_s
       end

--- a/spec/metrics/relation_spec.rb
+++ b/spec/metrics/relation_spec.rb
@@ -67,9 +67,9 @@ describe Influxer::Relation, :query do
     end
 
     describe "#where" do
-      it "sgenerate valid conditions from hash" do
+      it "generate valid conditions from hash" do
         Timecop.freeze(Time.now)
-        expect(rel.where(user_id: 1, dummy: 'q', timer: Time.now).to_sql).to eq "select * from \"dummy\" where (user_id = 1) and (dummy = 'q') and (timer = #{Time.now.to_i}s)"
+        expect(rel.where(user_id: 1, dummy: 'q', timer: Time.now).to_sql).to eq "select * from \"dummy\" where (user_id = 1) and (dummy = 'q') and (timer = #{(Time.now.to_r * 1_000_000_000).to_i})"
       end
 
       it "generate valid conditions from strings" do
@@ -78,6 +78,14 @@ describe Influxer::Relation, :query do
 
       it "handle regexps" do
         expect(rel.where(user_id: 1, dummy: /^du.*/).to_sql).to eq "select * from \"dummy\" where (user_id = 1) and (dummy =~ /^du.*/)"
+      end
+
+      it "handle dates" do        
+        expect(rel.where(timer: Date.new(2015)).to_sql).to eq "select * from \"dummy\" where (timer = #{(Date.new(2015).to_time.to_r * 1_000_000_000).to_i})"
+      end
+
+      it "handle date times" do        
+        expect(rel.where(timer: DateTime.new(2015)).to_sql).to eq "select * from \"dummy\" where (timer = #{(DateTime.new(2015).to_time.to_r * 1_000_000_000).to_i})"
       end
 
       it "handle ranges" do


### PR DESCRIPTION
Hello,

in this pull request, I refactored the quoting of timestamps. I extracted the quoting of timestamps into an own module and use this module in the `Metrics` and `Relation` classes.

Previously, the `Metrics` class used nanoseconds for writing data points and the `Relation` class used seconds. This implementation caused an issue when the same timestamp was used for writing and querying data:
```ruby
# write data point with current timestamp
point = DummyMetrics.new dummy_id: 1, user_id: 1
point.write
# read back data points with same timestamp
points = DummyMetrics.where(time: point.timestamp).all # result is empty because timestamp is converted to seconds and is missing last digits
```
A query with the same timestamp returns an empty result set because the timestamp is rounded to seconds.

Greetings

Marcel