### PR TITLE
added quoting to timestamp ranges. Added specs for time ranges

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## master
+- [Fixes [#37](https://github.com/palkan/influxer/issues/37)] Timestamp ranges are quoted again
 
 - [Fixes [#35](https://github.com/palkan/influxer/issues/35)] Support time duration suffix and handle `'s'` and `'ms'` precisions. ([@palkan][])
 

--- a/lib/influxer/metrics/relation/where_clause.rb
+++ b/lib/influxer/metrics/relation/where_clause.rb
@@ -83,16 +83,16 @@ module Influxer
       if val.exclude_end?
         # begin...end range
         if negate
-          "#{key} < #{quoted(val.begin)} or #{key} >= #{quoted(val.end)}"
+          "#{key} < #{quoted(val.begin, key)} or #{key} >= #{quoted(val.end, key)}"
         else
-          "#{key} >= #{quoted(val.begin)} and #{key} < #{quoted(val.end)}"
+          "#{key} >= #{quoted(val.begin, key)} and #{key} < #{quoted(val.end, key)}"
         end
       else
         # begin..end range
         if negate
-          "#{key} < #{quoted(val.begin)} or #{key} > #{quoted(val.end)}"
+          "#{key} < #{quoted(val.begin, key)} or #{key} > #{quoted(val.end, key)}"
         else
-          "#{key} >= #{quoted(val.begin)} and #{key} <= #{quoted(val.end)}"
+          "#{key} >= #{quoted(val.begin, key)} and #{key} <= #{quoted(val.end, key)}"
         end
       end
     end

--- a/spec/metrics/relation_spec.rb
+++ b/spec/metrics/relation_spec.rb
@@ -88,6 +88,14 @@ describe Influxer::Relation, :query do
         expect(rel.where(time: DateTime.new(2015)).to_sql).to eq "select * from \"dummy\" where (time = #{(DateTime.new(2015).to_time.to_r * 1_000_000_000).to_i})"
       end
 
+      it "handle date ranges" do
+        expect(rel.where(time: Date.new(2015)..Date.new(2016)).to_sql).to eq "select * from \"dummy\" where (time >= #{(Date.new(2015).to_time.to_r * 1_000_000_000).to_i} and time <= #{(Date.new(2016).to_time.to_r * 1_000_000_000).to_i})"
+      end
+
+      it "handle date time ranges" do
+        expect(rel.where(time: DateTime.new(2015)..DateTime.new(2016)).to_sql).to eq "select * from \"dummy\" where (time >= #{(DateTime.new(2015).to_time.to_r * 1_000_000_000).to_i} and time <= #{(DateTime.new(2016).to_time.to_r * 1_000_000_000).to_i})"
+      end
+
       it "handle inclusive ranges" do
         expect(rel.where(user_id: 1..4).to_sql).to eq "select * from \"dummy\" where (user_id >= 1 and user_id <= 4)"
       end


### PR DESCRIPTION
should fix issue #37 for now, nevertheless it might make  sense to quote all values for time columns.