### PR TITLE
This PR fixes issue #41

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 1.1.6
+
+- [Fixes [#41](https://github.com/palkan/influxer/issues/41)] Fix query building with empty arrays in `where` clause ([@dimiii][])
+
+  [PR](https://github.com/palkan/influxer/pull/44)
+
+  **BREAKING:** So far as the latest versions of influxdb fail on queries like `select * from dummy where 1 = 0`, instead of 
+  classic expression `(1 = 0)` influxdb specific `(time < 0)` is used for querying by an empty array. 
+  
 ## Misc 
 - Support of year alias in queries ([@dimiii][])
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,8 @@
 - [Fixes [#41](https://github.com/palkan/influxer/issues/41)] Fix query building with empty arrays in `where` clause ([@dimiii][])
 
   [PR](https://github.com/palkan/influxer/pull/44)
-
-  **BREAKING:** So far as the latest versions of influxdb fail on queries like `select * from dummy where 1 = 0`, instead of 
-  classic expression `(1 = 0)` influxdb specific `(time < 0)` is used for querying by an empty array. 
+   
+  **BREAKING:** `where.not` now returns non-empty result for an empty array.
   
 ## Misc 
 - Support of year alias in queries ([@dimiii][])

--- a/lib/influxer/metrics/relation/where_clause.rb
+++ b/lib/influxer/metrics/relation/where_clause.rb
@@ -59,7 +59,7 @@ module Influxer
       when Regexp
         "#{key}#{negate ? ' !~ ' : ' =~ '}#{val.inspect}"
       when Array
-        return build_none if val.empty?
+        return build_none(negate) if val.empty?
         build_in(key, val, negate)
       when Range
         build_range(key, val, negate)
@@ -98,9 +98,9 @@ module Influxer
     end
     # rubocop: enable Metrics/AbcSize, Metrics/MethodLength, Style/IfInsideElse
 
-    def build_none
-      @null_relation = true
-      build_eql(1, 0, false)
+    def build_none(negate = false)
+      @null_relation = !negate
+      negate ? 'time >= 0' : 'time < 0'
     end
   end
 end

--- a/spec/metrics/relation_spec.rb
+++ b/spec/metrics/relation_spec.rb
@@ -109,7 +109,7 @@ describe Influxer::Relation, :query do
       end
 
       it "handle empty arrays", :aggregate_failures do
-        expect(rel.where(user_id: []).to_sql).to eq "select * from \"dummy\" where (1 = 0)"
+        expect(rel.where(user_id: []).to_sql).to eq "select * from \"dummy\" where (time < 0)"
         expect(rel.to_a).to eq []
       end
 
@@ -181,8 +181,7 @@ describe Influxer::Relation, :query do
       end
 
       it "handle empty arrays", :aggregate_failures do
-        expect(rel.where.not(user_id: []).to_sql).to eq "select * from \"dummy\" where (1 = 0)"
-        expect(rel.to_a).to eq []
+        expect(rel.where.not(user_id: []).to_sql).to eq "select * from \"dummy\" where (time >= 0)"
       end
 
       context "with tags" do
@@ -194,13 +193,13 @@ describe Influxer::Relation, :query do
 
     describe "#none" do
       it "returns empty array", :aggregate_failures do
-        expect(rel.none.to_sql).to eq "select * from \"dummy\" where (1 = 0)"
+        expect(rel.none.to_sql).to eq "select * from \"dummy\" where (time < 0)"
         expect(rel.to_a).to eq []
       end
 
       it "works with chaining", :aggregate_failures do
         expect(rel.none.where.not(user_id: 1, dummy: :a).to_sql)
-          .to eq "select * from \"dummy\" where (1 = 0) and (user_id <> 1) and (dummy <> 'a')"
+          .to eq "select * from \"dummy\" where (time < 0) and (user_id <> 1) and (dummy <> 'a')"
         expect(rel.to_a).to eq []
       end
     end


### PR DESCRIPTION
Influxdb at least since 1.4.2 does not process queries like 'select * from dummy where 1 = 0'

Please, note also as I changed tests for the negation of the none-expression.