### PR TITLE
Fix configuration cache options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+- Fixes [#49](https://github.com/palkan/influxer/issues/49)  Cache hash configuration cannot be applied.([@AlexanderShvaykin][])
+- Fixes [#47](https://github.com/palkan/influxer/issues/47) Can't delete data when retention policy is set for a metric. ([@MPursche][])
+
 ## 1.2.1 (2020-07-09)
 
 - Support for setting timezone in queries to configure influx time calculations, e.g., time epoch aggregation ([@jklimke][])
@@ -90,3 +93,4 @@ See [changelog](https://github.com/palkan/influxer/blob/1.0.0/Changelog.md) for 
 [@MPursche]: https://github.com/MPursche
 [@jklimke]: https://github.com/jklimke
 [@dimiii]: https://github.com/dimiii
+[@AlexanderShvaykin]: https://github.com/AlexanderShvaykin

--- a/lib/influxer/config.rb
+++ b/lib/influxer/config.rb
@@ -28,15 +28,16 @@ module Influxer
                 :denormalize,
                 :udp,
                 :async,
+                :cache_enabled,
                 database: "db",
                 time_precision: "ns",
-                cache: false,
+                cache: {}.with_indifferent_access,
                 time_duration_suffix_enabled: false
 
     def load(*)
       super
       # we want pass @cache value as options to cache store, so we want it to be a Hash
-      @cache = {}.with_indifferent_access if @cache == true
+      self.cache_enabled = false if cache.blank?
     end
   end
 end

--- a/lib/influxer/config.rb
+++ b/lib/influxer/config.rb
@@ -34,10 +34,8 @@ module Influxer
                 cache: {}.with_indifferent_access,
                 time_duration_suffix_enabled: false
 
-    def load(*)
-      super
-      # we want pass @cache value as options to cache store, so we want it to be a Hash
-      self.cache_enabled = false if cache.blank?
+    def cache_enabled?
+      cache&.any? || false
     end
   end
 end

--- a/lib/influxer/config.rb
+++ b/lib/influxer/config.rb
@@ -29,13 +29,27 @@ module Influxer
                 :udp,
                 :async,
                 :cache_enabled,
+                :cache,
                 database: "db",
                 time_precision: "ns",
-                cache: {}.with_indifferent_access,
                 time_duration_suffix_enabled: false
 
-    def cache_enabled?
-      cache&.any? || false
+    def load(*)
+      super
+      if cache_enabled.nil?
+        self.cache_enabled = cache_enabled_value
+      end
+    end
+
+    def cache=(value)
+      super
+      self.cache_enabled = cache_enabled_value
+    end
+
+    private
+
+    def cache_enabled_value
+      !(cache == false || cache.nil?)
     end
   end
 end

--- a/lib/influxer/config.rb
+++ b/lib/influxer/config.rb
@@ -49,7 +49,7 @@ module Influxer
     private
 
     def cache_enabled_value
-      !(cache == false || cache.nil?)
+      !!cache
     end
   end
 end

--- a/lib/influxer/rails/client.rb
+++ b/lib/influxer/rails/client.rb
@@ -6,10 +6,10 @@ module Influxer
   class Client
     def query(sql, options = {})
       log_sql(sql) do
-        if !options.fetch(:cache, true) || Influxer.config.cache == false
-          super(sql, options)
+        if !options.fetch(:cache, true) || Influxer.config.cache_enabled == false
+          super(sql, **options)
         else
-          Rails.cache.fetch(normalized_cache_key(sql), cache_options(sql)) { super(sql, options) }
+          Rails.cache.fetch(normalized_cache_key(sql), **cache_options(sql)) { super(sql, **options) }
         end
       end
     end
@@ -34,7 +34,7 @@ module Influxer
     def cache_options(sql = nil)
       options = Influxer.config.cache.dup
       options[:expires_in] = (options[:cache_now_for] || 60) if /\snow\(\)/.match?(sql)
-      options
+      options.symbolize_keys
     end
 
     # add prefix; remove whitespaces

--- a/lib/influxer/rails/client.rb
+++ b/lib/influxer/rails/client.rb
@@ -6,7 +6,7 @@ module Influxer
   class Client
     def query(sql, options = {})
       log_sql(sql) do
-        if !options.fetch(:cache, true) || Influxer.config.cache_enabled == false
+        if !(options.fetch(:cache, true) && Influxer.config.cache_enabled)
           super(sql, **options)
         else
           Rails.cache.fetch(normalized_cache_key(sql), **cache_options(sql)) { super(sql, **options) }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -42,5 +42,20 @@ describe Influxer::Client do
       Timecop.travel(2.minutes.from_now)
       expect(Rails.cache.exist?("influxer:listseries")).to be_falsey
     end
+
+    it "does not write data to cache if disabled" do
+      conf.cache = {}
+      conf.cache_enabled = false
+
+      subject.query(q)
+      expect(Rails.cache.exist?("influxer:listseries")).to be_falsey
+    end
+
+    it "does not write data to cache without cache config" do
+      conf.cache = nil
+
+      subject.query(q)
+      expect(Rails.cache.exist?("influxer:listseries")).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix issue #49 

## What changes did you make? (overview)

Add cache_enabled config key.
Configure cache_enabled after load in relation to cache config, for backward compatibility. Change cache_enabled value with each change cache config, if you configure it after loading the configuration

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
