### PR TITLE
ruby 3 - added support for providing hash objects as arguments to where conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- added support for providing hash objects as arguments to where condition in ruby >= 3
+
 ## 1.4.0 (2022-01-24)
 
 - Fixes [#55](https://github.com/palkan/influxer/issues/55) Rails 7 deprecation warning
@@ -15,7 +17,7 @@
 
 ## 1.2.2 (2020-10-27)
 
-- Fixes [#49](https://github.com/palkan/influxer/issues/49)  Cache hash configuration cannot be applied.([@AlexanderShvaykin][])
+- Fixes [#49](https://github.com/palkan/influxer/issues/49) Cache hash configuration cannot be applied.([@AlexanderShvaykin][])
 - Fixes [#47](https://github.com/palkan/influxer/issues/47) Can't delete data when retention policy is set for a metric. ([@MPursche][])
 
 ## 1.2.1 (2020-07-09)
@@ -103,7 +105,7 @@ end
 See [changelog](https://github.com/palkan/influxer/blob/1.0.0/Changelog.md) for earlier versions.
 
 [@palkan]: https://github.com/palkan
-[@MPursche]: https://github.com/MPursche
+[@mpursche]: https://github.com/MPursche
 [@jklimke]: https://github.com/jklimke
 [@dimiii]: https://github.com/dimiii
-[@AlexanderShvaykin]: https://github.com/AlexanderShvaykin
+[@alexandershvaykin]: https://github.com/AlexanderShvaykin

--- a/lib/influxer/metrics/relation/where_clause.rb
+++ b/lib/influxer/metrics/relation/where_clause.rb
@@ -35,9 +35,15 @@ module Influxer
 
     protected
 
-    def build_where(args, hargs, negate)
-      if args.present? && args[0].is_a?(String)
-        where_values.concat(args.map { |str| "(#{str})" })
+    def build_where(args, hargs, negate)      
+      if args.present?
+        if args[0].is_a?(String)
+          where_values.concat(args.map { |str| "(#{str})" })
+        elsif args[0].is_a?(Hash)
+          build_hash_where(args[0], negate)
+        else
+          false
+        end
       elsif hargs.present?
         build_hash_where(hargs, negate)
       else

--- a/lib/influxer/metrics/relation/where_clause.rb
+++ b/lib/influxer/metrics/relation/where_clause.rb
@@ -35,7 +35,7 @@ module Influxer
 
     protected
 
-    def build_where(args, hargs, negate)      
+    def build_where(args, hargs, negate)
       if args.present?
         if args[0].is_a?(String)
           where_values.concat(args.map { |str| "(#{str})" })

--- a/spec/metrics/relation_spec.rb
+++ b/spec/metrics/relation_spec.rb
@@ -67,9 +67,15 @@ describe Influxer::Relation, :query do
     end
 
     describe "#where" do
-      it "generate valid conditions from hash" do
+      it "generate valid conditions from keyword arguments" do
         Timecop.freeze(Time.now)
         expect(rel.where(user_id: 1, dummy: "q", time: Time.now).to_sql).to eq "select * from \"dummy\" where (user_id = 1) and (dummy = 'q') and (time = #{(Time.now.to_r * 1_000_000_000).to_i})"
+      end
+
+      it "generate valid conditions from hash argument" do
+        Timecop.freeze(Time.now)
+        attributes = {user_id: 1, dummy: "q", time: Time.now}
+        expect(rel.where(attributes).to_sql).to eq "select * from \"dummy\" where (user_id = 1) and (dummy = 'q') and (time = #{(Time.now.to_r * 1_000_000_000).to_i})"
       end
 
       it "generate valid conditions from strings" do


### PR DESCRIPTION

## What is the purpose of this pull request?

When using ruby 3.1 I was not possible to pass hash objects to where conditions as this is possible in conventional active record where calls. Hash objects are interpreted as positional arguments and not extruded to hash parameters by default in ruby 3.

## What changes did you make? (overview)

* mainly added a check for handling hashes as first positional argument when buildign where conditions
* applied formatting to changelog
* added a test passing a hash object to where method of a relation

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [] I've updated a documentation
